### PR TITLE
Add constant to AM_CPPFLAGS for autotools build

### DIFF
--- a/axis_utils/Makefile.am
+++ b/axis_utils/Makefile.am
@@ -7,6 +7,7 @@
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
 
 # Build this uninstalled convenience library.
 noinst_LTLIBRARIES = libaxis_utils.la

--- a/coupler/Makefile.am
+++ b/coupler/Makefile.am
@@ -5,6 +5,7 @@
 
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/time_manager

--- a/field_manager/Makefile.am
+++ b/field_manager/Makefile.am
@@ -5,6 +5,7 @@
 
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms
 

--- a/station_data/Makefile.am
+++ b/station_data/Makefile.am
@@ -6,6 +6,7 @@
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/axis_utils
+AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/diag_manager

--- a/time_interp/Makefile.am
+++ b/time_interp/Makefile.am
@@ -6,6 +6,7 @@
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
 AM_CPPFLAGS += -I${top_builddir}/time_manager
+AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/axis_utils

--- a/tracer_manager/Makefile.am
+++ b/tracer_manager/Makefile.am
@@ -5,6 +5,7 @@
 
 # Include .h and .mod files.
 AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS += -I${top_builddir}/constants
 AM_CPPFLAGS += -I${top_builddir}/mpp
 AM_CPPFLAGS += -I${top_builddir}/fms
 AM_CPPFLAGS += -I${top_builddir}/field_manager


### PR DESCRIPTION
At least one Intel compiler version (18.0.3) required the `-I../constants` directory added for components that use the fms_mod.mod file.