### PR TITLE
automake Makefiles use *.mod files as dependencies

### DIFF
--- a/coupler/Makefile.am
+++ b/coupler/Makefile.am
@@ -28,7 +28,7 @@ ensemble_manager_mod.mod: ensemble_manager.$(OBJEXT)
 atmos_ocean_fluxes_mod.mod: atmos_ocean_fluxes.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-atmos_ocean_fluxes.$(OBJEXT): coupler_types.$(OBJEXT)
+atmos_ocean_fluxes.$(OBJEXT): coupler_types_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = coupler_types_mod.mod ensemble_manager_mod.mod	\

--- a/diag_manager/Makefile.am
+++ b/diag_manager/Makefile.am
@@ -36,12 +36,12 @@ diag_output_mod.mod: diag_output.$(OBJEXT)
 diag_util_mod.mod: diag_util.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-diag_axis.$(OBJEXT): diag_data.$(OBJEXT)
-diag_manifest.$(OBJEXT): diag_data.$(OBJEXT)
-diag_output.$(OBJEXT): diag_axis.$(OBJEXT) diag_data.$(OBJEXT)
-diag_util.$(OBJEXT): diag_data.$(OBJEXT) diag_axis.$(OBJEXT) diag_output.$(OBJEXT) diag_grid.$(OBJEXT)
-diag_table.$(OBJEXT): diag_data.$(OBJEXT) diag_util.$(OBJEXT)
-diag_manager.$(OBJEXT): diag_axis.$(OBJEXT) diag_data.$(OBJEXT) diag_util.$(OBJEXT) diag_output.$(OBJEXT) diag_grid.$(OBJEXT) diag_table.$(OBJEXT) diag_manifest.$(OBJEXT)
+diag_axis.$(OBJEXT): diag_data_mod.mod
+diag_manifest.$(OBJEXT): diag_data_mod.mod
+diag_output.$(OBJEXT): diag_axis_mod.mod diag_data_mod.mod
+diag_util.$(OBJEXT): diag_data_mod.mod diag_axis_mod.mod diag_output_mod.mod diag_grid_mod.mod
+diag_table.$(OBJEXT): diag_data_mod.mod diag_util_mod.mod
+diag_manager.$(OBJEXT): diag_axis_mod.mod diag_data_mod.mod diag_util_mod.mod diag_output_mod.mod diag_grid_mod.mod diag_table_mod.mod diag_manifest_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = diag_data_mod.mod diag_axis_mod.mod diag_grid_mod.mod	\

--- a/exchange/Makefile.am
+++ b/exchange/Makefile.am
@@ -24,7 +24,7 @@ stock_constants_mod.mod: stock_constants.$(OBJEXT)
 xgrid_mod.mod: xgrid.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-xgrid.$(OBJEXT): stock_constants.$(OBJEXT)
+xgrid.$(OBJEXT): stock_constants_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = stock_constants_mod.mod xgrid_mod.mod

--- a/fft/Makefile.am
+++ b/fft/Makefile.am
@@ -22,7 +22,7 @@ fft99_mod.mod: fft99.$(OBJEXT)
 fft_mod.mod: fft.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-fft.$(OBJEXT): fft99.$(OBJEXT)
+fft.$(OBJEXT): fft99_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = fft99_mod.mod fft_mod.mod

--- a/field_manager/Makefile.am
+++ b/field_manager/Makefile.am
@@ -21,7 +21,7 @@ field_manager_mod.mod: field_manager.$(OBJEXT)
 fm_util_mod.mod: fm_util.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-fm_util.$(OBJEXT): field_manager.$(OBJEXT)
+fm_util.$(OBJEXT): field_manager_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = field_manager_mod.mod fm_util_mod.mod

--- a/fms/Makefile.am
+++ b/fms/Makefile.am
@@ -34,7 +34,7 @@ fms_io_mod.mod: fms_io.$(OBJEXT)
 fms_mod.mod: fms.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-fms.$(OBJEXT): fms_io.$(OBJEXT)
+fms.$(OBJEXT): fms_io_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = fms_io_mod.mod fms_mod.mod

--- a/horiz_interp/Makefile.am
+++ b/horiz_interp/Makefile.am
@@ -32,12 +32,12 @@ horiz_interp_spherical_mod.mod: horiz_interp_spherical.$(OBJEXT)
 horiz_interp_mod.mod: horiz_interp.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-horiz_interp_bicubic.$(OBJEXT): horiz_interp_type.$(OBJEXT)
-horiz_interp_bilinear.$(OBJEXT): horiz_interp_type.$(OBJEXT)
-horiz_interp_conserve.$(OBJEXT): horiz_interp_type.$(OBJEXT)
-horiz_interp_spherical.$(OBJEXT): horiz_interp_type.$(OBJEXT)
-horiz_interp.$(OBJEXT): horiz_interp_bicubic.$(OBJEXT) horiz_interp_type.$(OBJEXT) \
-	horiz_interp_bilinear.$(OBJEXT) horiz_interp_conserve.$(OBJEXT) horiz_interp_spherical.$(OBJEXT)
+horiz_interp_bicubic.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp_bilinear.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp_conserve.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp_spherical.$(OBJEXT): horiz_interp_type_mod.mod
+horiz_interp.$(OBJEXT): horiz_interp_bicubic_mod.mod horiz_interp_type_mod.mod \
+	horiz_interp_bilinear_mod.mod horiz_interp_conserve_mod.mod horiz_interp_spherical_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = horiz_interp_type_mod.mod horiz_interp_bicubic_mod.mod	\

--- a/mosaic/Makefile.am
+++ b/mosaic/Makefile.am
@@ -28,7 +28,7 @@ grid_mod.mod: grid.$(OBJEXT)
 gradient_mod.mod: gradient.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-grid.$(OBJEXT): mosaic.$(OBJEXT)
+grid.$(OBJEXT): mosaic_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = mosaic_mod.mod grid_mod.mod gradient_mod.mod

--- a/mpp/Makefile.am
+++ b/mpp/Makefile.am
@@ -39,15 +39,15 @@ mpp_domains_mod.mod: mpp_domains.$(OBJEXT)
 mpp_io_mod.mod: mpp_io.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-mpp_data.$(OBJEXT): mpp_parameter.$(OBJEXT)
-mpp.$(OBJEXT): mpp_data.$(OBJEXT)
-mpp_utilities.$(OBJEXT): mpp.$(OBJEXT) mpp_efp.$(OBJEXT)
-mpp_memutils.$(OBJEXT): mpp.$(OBJEXT)
-mpp_pset.$(OBJEXT): mpp.$(OBJEXT)
-mpp_efp.$(OBJEXT): mpp_efp.$(OBJEXT) mpp_parameter.$(OBJEXT) mpp.$(OBJEXT)
-mpp_domains.$(OBJEXT): mpp_data.$(OBJEXT) mpp_parameter.$(OBJEXT) \
-	mpp.$(OBJEXT) mpp_memutils.$(OBJEXT) mpp_pset.$(OBJEXT) mpp_efp.$(OBJEXT)
-mpp_io.$(OBJEXT): mpp_parameter.$(OBJEXT) mpp.$(OBJEXT) mpp_domains.$(OBJEXT)
+mpp_data.$(OBJEXT): mpp_parameter_mod.mod
+mpp.$(OBJEXT): mpp_data_mod.mod
+mpp_utilities.$(OBJEXT): mpp_mod.mod mpp_efp_mod.mod
+mpp_memutils.$(OBJEXT): mpp_mod.mod
+mpp_pset.$(OBJEXT): mpp_mod.mod
+mpp_efp.$(OBJEXT): mpp_efp_mod.mod mpp_parameter_mod.mod mpp_mod.mod
+mpp_domains.$(OBJEXT): mpp_data_mod.mod mpp_parameter_mod.mod \
+	mpp_mod.mod mpp_memutils_mod.mod mpp_pset_mod.mod mpp_efp_mod.mod
+mpp_io.$(OBJEXT): mpp_parameter_mod.mod mpp_mod.mod mpp_domains_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = mpp_parameter_mod.mod mpp_data_mod.mod mpp_mod.mod	\

--- a/oda_tools/Makefile.am
+++ b/oda_tools/Makefile.am
@@ -32,8 +32,8 @@ write_ocean_data_mod.mod: write_ocean_data.$(OBJEXT)
 oda_core_mod.mod: oda_core.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-write_ocean_data.$(OBJEXT): oda_types.$(OBJEXT)
-oda_core.$(OBJEXT): oda_types.$(OBJEXT) write_ocean_data.$(OBJEXT)
+write_ocean_data.$(OBJEXT): oda_types_mod.mod
+oda_core.$(OBJEXT): oda_types_mod.mod write_ocean_data_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = oda_types_mod.mod write_ocean_data_mod.mod	\

--- a/random_numbers/Makefile.am
+++ b/random_numbers/Makefile.am
@@ -19,7 +19,7 @@ random_numbers_mod.mod: random_numbers.$(OBJEXT)
 mersennetwister_mod.mod: MersenneTwister.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-random_numbers.$(OBJEXT): MersenneTwister.$(OBJEXT)
+random_numbers.$(OBJEXT): mersennetwister_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = mersennetwister_mod.mod random_numbers_mod.mod

--- a/sat_vapor_pres/Makefile.am
+++ b/sat_vapor_pres/Makefile.am
@@ -21,7 +21,7 @@ sat_vapor_pres_mod.mod: sat_vapor_pres.$(OBJEXT)
 sat_vapor_pres_k_mod.mod: sat_vapor_pres_k.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-sat_vapor_pres.$(OBJEXT): sat_vapor_pres_k.$(OBJEXT)
+sat_vapor_pres.$(OBJEXT): sat_vapor_pres_k_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = sat_vapor_pres_k_mod.mod sat_vapor_pres_mod.mod

--- a/test_fms/Makefile.am
+++ b/test_fms/Makefile.am
@@ -5,6 +5,7 @@
 
 # Find the fms_mod.mod file.
 AM_CPPFLAGS = -I${top_builddir}/fms
+AM_CPPFLAGS += -I${top_builddir}/constants
 
 # Build this test program.
 check_PROGRAMS = tst_fms1

--- a/time_interp/Makefile.am
+++ b/time_interp/Makefile.am
@@ -25,7 +25,7 @@ time_interp_mod.mod: time_interp.$(OBJEXT)
 time_interp_external_mod.mod: time_interp_external.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-time_interp_external.$(OBJEXT):  time_interp.$(OBJEXT)
+time_interp_external.$(OBJEXT):  time_interp_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = time_interp_mod.mod time_interp_external_mod.mod

--- a/time_manager/Makefile.am
+++ b/time_manager/Makefile.am
@@ -21,7 +21,7 @@ time_manager_mod.mod: time_manager.$(OBJEXT)
 get_cal_time_mod.mod: get_cal_time.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-get_cal_time.$(OBJEXT): time_manager.$(OBJEXT)
+get_cal_time.$(OBJEXT): time_manager_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = time_manager_mod.mod get_cal_time_mod.mod

--- a/topography/Makefile.am
+++ b/topography/Makefile.am
@@ -22,7 +22,7 @@ gaussian_topog_mod.mod: gaussian_topog.$(OBJEXT)
 topography_mod.mod: topography.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-topography.$(OBJEXT): gaussian_topog.$(OBJEXT)
+topography.$(OBJEXT): gaussian_topog_mod.mod
 
 # Mod files are built and then installed as headers.
 MODFILES = gaussian_topog_mod.mod topography_mod.mod


### PR DESCRIPTION
Using the *.mod files as dependencies instead of the object file resolves parallel build issues.